### PR TITLE
fix: k8s 환경을 위한 chromadb lazy loading 적용

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -7,6 +7,7 @@ from models.wiki.wiki_chain import WikiSummarizer
 from nodes.graph import MeetingWorkflow
 from .config import CHROMA_HOST, CHROMA_PORT, USER_INFO_DB_URL
 from .exceptions import ChromaDBConnectionError, DatabaseError
+from vectordb.chroma_store import ChromaDBManager
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +17,6 @@ def get_chroma_client():
     """ChromaDB 클라이언트 인스턴스를 반환합니다."""
     try:
         client = chromadb.HttpClient(host=CHROMA_HOST, port=CHROMA_PORT)
-        # Test connection
-        client.heartbeat()
         logger.info("Connected to ChromaDB successfully")
         return client
     except Exception as e:
@@ -43,9 +42,9 @@ def get_database_engine():
 # Service dependencies
 @lru_cache()
 def get_wiki_summarizer():
-    """WikiSummarizer 인스턴스를 반환합니다."""
     try:
-        return WikiSummarizer()
+        chroma = ChromaDBManager() 
+        return WikiSummarizer(embed_func=chroma)
     except Exception as e:
         logger.error(f"Failed to initialize WikiSummarizer: {e}")
         raise

--- a/models/wiki/wiki_chain.py
+++ b/models/wiki/wiki_chain.py
@@ -19,12 +19,14 @@ class WikiSummarizer:
     def __init__(
         self,
         model_name: str = "naver-hyperclovax/HyperCLOVAX-SEED-Text-Instruct-1.5B",
-        embed_func=ChromaDBManager()
+        embed_func=None
     ):
+        if embed_func is None:
+            embed_func = ChromaDBManager()
         logger.info("Initializing WikiSummarizer...")
         self.embed_func = embed_func.embed_and_store
         logger.info("WikiSummarizer initialization complete")
-
+        
     def summarize_wiki(self, state: dict) -> dict:
         logger.info(f"Starting wiki summarization for project_id: {state.get('project_id')}")
         content = state.get("content")

--- a/vectordb/chroma_store.py
+++ b/vectordb/chroma_store.py
@@ -1,3 +1,5 @@
+import os
+import time
 import chromadb
 from .embed_model import CustomEmbeddingFunction
 from app.config import CHROMA_HOST, CHROMA_PORT
@@ -7,59 +9,78 @@ logger = logging.getLogger(__name__)
 
 class ChromaDBManager:
     def __init__(self, collection_name="wiki_summaries", host=CHROMA_HOST, port=CHROMA_PORT):
-        self.client = chromadb.HttpClient(host=host, port=port)
+        self._host = os.getenv("CHROMA_HOST", host)
+        self._port = int(os.getenv("CHROMA_PORT", port))
         self.collection_name = collection_name
-        self.collection = self.client.get_or_create_collection(name=collection_name)
         self.embedding_function = CustomEmbeddingFunction()
-    
+
+        self._client = None
+        self._collection = None
+
+    def _init_client(self):
+        retries = 5
+        delay = 2
+        for i in range(retries):
+            try:
+                return chromadb.HttpClient(host=self._host, port=self._port)
+            except Exception as e:
+                logger.warning(f"ChromaDB 연결 실패 ({i+1}/{retries}): {e}")
+                time.sleep(delay)
+        raise ConnectionError(f"ChromaDB 연결 실패: {self._host}:{self._port}")
+
+    def get_client(self):
+        if self._client is None:
+            self._client = self._init_client()
+        return self._client
+
+    def get_collection(self):
+        if self._collection is None:
+            self._collection = self.get_client().get_or_create_collection(name=self.collection_name)
+        return self._collection
+
     def embed_and_store(self, summary: str, metadata: dict):
         doc_id = f"{metadata['project_id']}_{metadata.get('document_path', 'unknown')}_{metadata.get('updated_at', 'unknown')}"
         
         try:
-            self.collection.delete(ids=[doc_id])
+            self.get_collection().delete(ids=[doc_id])
         except:
             pass  # 기존 문서가 없으면 무시
-        
-        # 새 문서 추가
+
         embedding = self.embedding_function([summary])[0]
-        self.collection.add(
+        self.get_collection().add(
             ids=[doc_id], 
             documents=[summary], 
             embeddings=[embedding], 
             metadatas=[metadata]
         )
-        
+
         print(f"문서 저장 완료: {doc_id}")
         return doc_id
-    
+
     def search(self, query_text, n_results=5, where_filter=None):
         query_embedding = self.embedding_function([query_text])[0]
-        results = self.collection.query(
+        return self.get_collection().query(
             query_embeddings=[query_embedding],
             n_results=n_results,
             where=where_filter
         )
-        return results
-    
+
     def get_by_project_id(self, project_id):
-        return self.collection.get(where={"project_id": project_id})
-    
+        return self.get_collection().get(where={"project_id": project_id})
+
     def delete_by_project_id(self, project_id):
         try:
-            existing_docs = self.collection.get(where={"project_id": project_id})
+            existing_docs = self.get_collection().get(where={"project_id": project_id})
             doc_count = len(existing_docs['ids']) if existing_docs['ids'] else 0
-            
+
             if doc_count == 0:
                 logger.info(f"프로젝트 {project_id}: 삭제할 ChromaDB 문서가 없습니다")
                 return True
-            
-            self.collection.delete(where={"project_id": project_id})
+
+            self.get_collection().delete(where={"project_id": project_id})
             logger.info(f"프로젝트 {project_id} ChromaDB 데이터 삭제 완료 ({doc_count}개 문서)")
             return True
-            
+
         except Exception as e:
             logger.error(f"프로젝트 {project_id} ChromaDB 삭제 실패: {e}")
             return False
-
-
-default_db_manager = ChromaDBManager()


### PR DESCRIPTION
## ☝️Issue Number
- resolve #173 

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📌 개요
- Kubernetes 환경에서 ai-summary 서비스가 ChromaDB import 시점에 연결을 시도하여 앱이 CrashLoopBackOff 상태에 빠지는 문제를 해결
- ChromaDB 연결을 lazy-loading 방식으로 변경하여 앱이 완전히 기동된 이후에만 db 연결이 이루어지도록 수정

## 🔎 Key Changes
- `vectordb/chroma_store.py`: 전역 인스턴스 삭제 (`default_db_manager`) 및 HttpClient/collection 지연 로딩 처리
- `WikiSummarizer`: `embed_func=ChromaDBManager()` → `embed_func=None` 변경 및 내부 초기화
- `dependencies.py`:
  - `get_wiki_summarizer()`에서 명시적으로 ChromaDBManager 주입
  - `get_chroma_client()`의 `.heartbeat()` 호출 제거

## 💌 To Reviewers
- ChromaDBManager는 더 이상 import 시점에 연결을 수행하지 X

## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.